### PR TITLE
Add orchestrator decision loop, artifact store, and new hub controls

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -1,0 +1,48 @@
+"""Simple append-only artifact store for text blobs."""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from typing import Optional, Tuple
+
+ART_DIRNAME = "artifacts"
+INDEX_BASENAME = "index.jsonl"
+
+
+def _ensure_dir(root: str) -> str:
+    path = os.path.join(root, ART_DIRNAME)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _index_path(root: str) -> str:
+    return os.path.join(_ensure_dir(root), INDEX_BASENAME)
+
+
+def _blob_path(root: str, art_id: str) -> str:
+    return os.path.join(_ensure_dir(root), f"{art_id}.txt")
+
+
+def store_text(root: str, kind: str, body: str, meta: Optional[dict] = None) -> str:
+    """Persist a text artifact and return its identifier."""
+    now = int(time.time())
+    art_id = f"{now}-{uuid.uuid4().hex[:8]}"
+    with open(_blob_path(root, art_id), "w", encoding="utf-8") as handle:
+        handle.write(body or "")
+    record = {"id": art_id, "kind": kind, "ts": now, "meta": meta or {}}
+    with open(_index_path(root), "a", encoding="utf-8") as index:
+        index.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return art_id
+
+
+def load_text(root: str, art_id: str, max_chars: Optional[int] = None) -> Tuple[str, int]:
+    """Load a stored text artifact returning (text, total_length)."""
+    path = _blob_path(root, art_id)
+    with open(path, "r", encoding="utf-8") as handle:
+        data = handle.read()
+    total = len(data)
+    if max_chars is not None and total > max_chars:
+        data = data[:max_chars]
+    return data, total


### PR DESCRIPTION
## Summary
- Introduces an orchestrator decision loop with debounced digest sending and a watchdog
- Adds a tiny append-only artifact store for storing and fetching text blobs (agent messages, completions, etc.)
- Implements new orchestrator control blocks (`status`, `fetch`, `spawn`, `send`, `close`) for fine-grained hub management
- Enhances the hub CLI with operator commands: `:decide`, `:wip`, `:recent` to interact with digest and decision logs
- Updates README.md with extensive documentation on orchestrator controls, digest behavior, and new operator commands

## Changes

### Core hub (`codex_hub_core.py`)
- Added artifact store integration to save agent messages and completions with metadata
- Track last check-in times and summaries per agent to inform decision-ready digests
- Orchestrator digest system: debounced digest generation, extra control blocks queuing, and sending via app-server
- Watchdog Loop:
  - Periodically checks agent check-in latency
  - Emits timeout events into the digest to alert stalled agents
- Support for orchestrator control blocks:
  - `status`: posts human-readable updates and optionally comments on GitHub issues
  - `fetch`: fetches stored artifacts on demand with character limits
  - `spawn`, `send`, `close`: control sub-agent lifecycle
- Maintains a decision log of digest sends and operator decisions
- Broadcasts event types for decisions, status posts, and artifact notes to update CLI's event stream

### CLI (`codex_hub_cli.py`)
- New commands:
  - `:decide` flushes a digest immediately to orchestrator
  - `:wip` shows active agents with statuses and check-in delays
  - `:recent` shows recent decision log or event stream entries
- Enhanced output formatting for agent lists to include last check-in latency
- Displays decision actions, status posts, and artifact fetch notifications in the event stream

### Artifacts Store (`artifacts.py`)
- New module providing append-only storage of text blobs with:
  - Persistent storage of text files with metadata
  - Indexed lookup via JSONL index
  - Partial loading of content with `max_chars` limit

### Documentation (`README.md`)
- Extended description of orchestrator role and the digest mechanism
- Detailed examples of orchestrator control blocks usage
- New operator CLI commands explained

## Test plan
- Validated storing and loading text artifacts
- Verified digest sending triggers after agent messages, completions, or status changes
- Tested `:decide` command forces digest send
- Confirmed watchdog emits TIMEOUT_CHECKIN events for delayed agents
- Confirmed orchestrator control blocks execute correctly
- Manual verification of CLI commands output and interaction
- Documentation rendered correctly and matches implemented features

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a2708017-50f7-444e-8993-e2b21f213ab2