### PR TITLE
hub: fix control-block regex; gate approvals via on-request + autopilot; move artifacts to .orch; broaden PR search; docs: clarify safety model, artifacts, and sandbox behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.py[cod]
+.orch/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for the **orchestrator** and one per **sub-agent** (per Issue).
 - Scheduler/watchdog enforces WIP limits, check-ins, nudges, and time budgets without blocking the REPL.
 - GitHub poller fills capacity from `orchestrate` issues, understands simple blockers, and posts one status comment.
 - Optional OTEL heartbeats by tailing a local JSONL log for per-conversation liveness.
-- Zero third-party Python dependencies (Python 3.10+).
+- Core has zero third-party Python dependencies (Python 3.10+). The optional web dashboard under `hub_dashboard/` uses `aiohttp`.
 
 ## Requirements
 
@@ -127,9 +127,11 @@ Acceptance, Scope and Validation.
 
 ### Safety/approvals
 
-By default, **autopilot** is enabled when you pass `--autopilot-on`. If also `--dangerous`
-is set, the orchestrator can emit an `exec` control block and the daemon will run `git`/`gh`
-commands locally in the right worktree. Turn either off to gate command execution.
+Safety model:
+
+- `--dangerous` controls the sandbox power for conversations (danger-full-access vs. workspace-write).
+- Approvals are always requested from the app-server; the hub auto-approves only when both `--dangerous` and autopilot are enabled.
+- Use `:autopilot on|off` at runtime to toggle automatic execution of CONTROL blocks and approvals.
 
 ## Orchestrator controls the hub (new)
 
@@ -253,3 +255,4 @@ service:
 
 Run the hub with `--otel-log /tmp/codex-otel.jsonl` to enable heartbeats from OTEL.
 
+Artifacts: the hub stores text artifacts under `.orch/artifacts/` and writes a rolling event log to `.orch/state.jsonl`. The `.orch/` directory is ignored by git.

--- a/app_server_client.py
+++ b/app_server_client.py
@@ -214,12 +214,9 @@ class AppServerProcess:
             params["model"] = model
         if workspace:
             params["cwd"] = workspace
-        if self.dangerous:
-            params["approvalPolicy"] = "never"
-            params["sandbox"] = "danger-full-access"
-        else:
-            params["approvalPolicy"] = "on-request"
-            params["sandbox"] = "workspace-write"
+        # Always request approvals so the hub can gate actions; sandbox level depends on danger.
+        params["approvalPolicy"] = "on-request"
+        params["sandbox"] = "danger-full-access" if self.dangerous else "workspace-write"
 
         resp = await self.call("newConversation", params=params, timeout=30.0)
         payload = resp.get("result") or {}

--- a/artifacts.py
+++ b/artifacts.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from typing import Optional, Tuple
 
-ART_DIRNAME = "artifacts"
+ART_DIRNAME = os.path.join(".orch", "artifacts")
 INDEX_BASENAME = "index.jsonl"
 
 

--- a/codex_hub_core.py
+++ b/codex_hub_core.py
@@ -55,7 +55,7 @@ SUBAGENT_SYSTEM_TEMPLATE = (
 
 FALLBACK_SYSTEM_PREFIX = "### SYSTEM MESSAGE (treat as system role) ###\n"
 CONTROL_BLOCK_RE = re.compile(
-    r"```(?:json\\s+)?control\\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE
+    r"```(?:json\s+)?control\s*\n(.*?)\n```", re.DOTALL | re.IGNORECASE
 )
 
 TEXT_ITEM_TYPES = {"text", "assistant_delta", "assistant_message"}
@@ -664,7 +664,7 @@ class Hub:
         )
 
     async def _autoapprove(self, request_id: Any, method: str, params: Dict[str, Any]) -> None:
-        approved = self.dangerous and self.autopilot_enabled
+        approved = bool(self.dangerous and self.autopilot_enabled)
         decision = "approved" if approved else "denied"
 
         description: str

--- a/github_sync.py
+++ b/github_sync.py
@@ -412,9 +412,9 @@ def update_comment(repo_path: str, comment_id: int, body: str) -> None:
 
 
 def fetch_prs_for_issue(repo_path: str, issue_number: int) -> List[Dict]:
-    """List PRs whose title references #<issue_number>."""
+    """List PRs that reference #<issue_number> in title or body."""
 
-    query = f'in:title "#{issue_number}"'
+    query = f'in:title,body "#{issue_number}"'
     raw = _ensure_success(
         _run_gh(
             [


### PR DESCRIPTION
This PR updates several hub and orchestrator behaviors and documentation:

- Fix the control-block regex to properly match `control` blocks with optional json specifiers.
- Change approval gating so that approvals are always requested on the app-server side and gated by the hub, with sandbox access level depending on the `--dangerous` flag.
- Move artifact storage under a new `.orch/artifacts/` directory and add `.orch/` to `.gitignore`.
- Broaden GitHub PR search queries to include references not only in titles but also in bodies.
- Enhance the README safety section to clarify the sandbox permission flags, approval gating logic, and the `.orch/` directory usage for artifacts and event logs.

These changes improve the security model clarity, artifact management, and GitHub interaction handling.

No additional manual notes or context have been changed or removed.

📎 **Task**: https://www.terragonlabs.com/task/5bbbd965-bc0f-4c34-88fb-8fb387820161